### PR TITLE
Add zsh function

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,16 @@ Put the next function into the **.bashrc** or a similar config:
 
 <table>
 <tr>
-  <th> Bash </th>
+  <th> Bash/zsh </th>
   <th> Fish </th>
 </tr>
 <tr>
 <td>
 
 ```bash
-function ll {
+alias ll && unalias ll # 'll' is often aliased to 'ls -l' - this will unalias it if so
+
+ll() {
   cd "$(llama "$@")"
 }
 ```


### PR DESCRIPTION
Common ZSH setups (such as `oh-my-zsh`) have `ll` aliased as `ls -l`. This impl will unalias `ll` if it exists