### PR TITLE
Better trimming of path location in bar

### DIFF
--- a/main.go
+++ b/main.go
@@ -529,9 +529,19 @@ start:
 		location = TrimSuffix(location, fileSeparator)
 		filter = fileSeparator + m.search
 	}
-	barLen := len(location) + len(filter)
-	if barLen > outputWidth {
-		location = location[min(barLen-outputWidth, len(location)):]
+	if len(location)+len(filter) > outputWidth {
+		// Shorten the path to only first letters.
+		arr := Split(location, fileSeparator)
+		for i, v := range arr {
+			arr[i] = v[0:1]
+		}
+		location = Join(arr, fileSeparator)
+
+		// Trim if still too much.
+		barLen := len(location) + len(filter)
+		if barLen > outputWidth {
+			location = "..." + location[min(barLen-outputWidth, len(location))+3:]
+		}
 	}
 	bar := bar.Render(location) + search.Render(filter)
 


### PR DESCRIPTION
1) If the path is too long then use only the first letters, for eg.
   `~/test/llama` -> `~/t/l`
2) If the path is still too long, use old strategy to remove certain
   number of letters from beginning. On top of that replace the first 3
   letters of new string with "...". For eg, `~/t/l/f/h` -> `.../f/h`

Partially resolves #78 