### PR TITLE
main: support full-width glyphs

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 	"github.com/muesli/termenv"
 	"github.com/sahilm/fuzzy"
 )
@@ -35,6 +36,7 @@ var (
 	danger        = lipgloss.NewStyle().Background(lipgloss.Color("#FF0000")).Foreground(lipgloss.Color("#FFFFFF"))
 	fileSeparator = string(filepath.Separator)
 	showIcons     = false
+	strlen        = runewidth.StringWidth
 )
 
 var (
@@ -177,7 +179,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 			} else if key.Matches(msg, keyBack) {
 				if len(m.search) > 0 {
-					m.search = m.search[:len(m.search)-1]
+					m.search = m.search[:strlen(m.search)-1]
 					return m, nil
 				}
 			} else if msg.Type == tea.KeyRunes {
@@ -422,7 +424,7 @@ func (m *model) View() string {
 	m.preview()
 
 	// Get output rows width before coloring.
-	outputWidth := len(path.Base(m.path)) // Use current dir name as default.
+	outputWidth := strlen(path.Base(m.path)) // Use current dir name as default.
 	if m.previewMode {
 		row := make([]string, m.columns)
 		for i := 0; i < m.columns; i++ {
@@ -432,7 +434,7 @@ func (m *model) View() string {
 				outputWidth = width
 			}
 		}
-		outputWidth = max(outputWidth, len(Join(row, separator)))
+		outputWidth = max(outputWidth, strlen(Join(row, separator)))
 	} else {
 		outputWidth = width
 	}
@@ -479,9 +481,9 @@ func (m *model) View() string {
 		location = TrimSuffix(location, fileSeparator)
 		filter = fileSeparator + m.search
 	}
-	barLen := len(location) + len(filter)
+	barLen := strlen(location) + strlen(filter)
 	if barLen > outputWidth {
-		location = location[min(barLen-outputWidth, len(location)):]
+		location = location[min(barLen-outputWidth, strlen(location)):]
 	}
 	barStr := bar.Render(location) + search.Render(filter)
 
@@ -830,14 +832,14 @@ start:
 				}
 				n++
 			}
-			if max < len(name) {
-				max = len(name)
+			if max < strlen(name) {
+				max = strlen(name)
 			}
 			names[i][j] = name
 		}
 		// Append spaces to make all names in one column of same size.
 		for j := 0; j < rows; j++ {
-			names[i][j] += Repeat(" ", max-len(names[i][j]))
+			names[i][j] += Repeat(" ", max-strlen(names[i][j]))
 		}
 	}
 	for j := 0; j < rows; j++ {
@@ -845,7 +847,7 @@ start:
 		for i := 0; i < columns; i++ {
 			row[i] = names[i][j]
 		}
-		if len(Join(row, separator)) > width && columns > 1 {
+		if strlen(Join(row, separator)) > width && columns > 1 {
 			// Yep. No luck, let's decrease number of columns and try one more time.
 			columns--
 			goto start


### PR DESCRIPTION
Uses "github.com/mattn/go-runewidth" to calculate the length (in bytes) of printed strings as they appear in terminals with wide character support (east asian glyphs). This is the same extension used to implement many standard emojis.