### PR TITLE
add `i` to enter and `o` to exit dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Now use `lk` command to start walking.
 | Key binding      | Description        |
 |------------------|--------------------|
 | `Arrows`, `hjkl` | Move cursor        |
-| `Enter`          | Enter directory    |
-| `Backspace`      | Exit directory     |
+| `Enter`, `i`     | Enter directory    |
+| `Backspace`, `o` | Exit directory     |
 | `Space`          | Toggle preview     |
 | `Esc`, `q`       | Exit with cd       |
 | `Ctrl+c`         | Exit without cd    |

--- a/main.go
+++ b/main.go
@@ -44,7 +44,9 @@ var (
 	keyQuit      = key.NewBinding(key.WithKeys("esc"))
 	keyQuitQ     = key.NewBinding(key.WithKeys("q"))
 	keyOpen      = key.NewBinding(key.WithKeys("enter"))
+	keyOpenI     = key.NewBinding(key.WithKeys("i"))
 	keyBack      = key.NewBinding(key.WithKeys("backspace"))
+	keyBackO     = key.NewBinding(key.WithKeys("o"))
 	keyUp        = key.NewBinding(key.WithKeys("up"))
 	keyDown      = key.NewBinding(key.WithKeys("down"))
 	keyLeft      = key.NewBinding(key.WithKeys("left"))
@@ -220,7 +222,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.performPendingDeletions()
 			return m, tea.Quit
 
-		case key.Matches(msg, keyOpen):
+		case key.Matches(msg, keyOpen, keyOpenI):
 			m.searchMode = false
 			filePath, ok := m.filePath()
 			if !ok {
@@ -244,7 +246,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, m.openEditor()
 			}
 
-		case key.Matches(msg, keyBack):
+		case key.Matches(msg, keyBack, keyBackO):
 			m.searchMode = false
 			m.prevName = filepath.Base(m.path)
 			m.path = filepath.Join(m.path, "..")


### PR DESCRIPTION
While navigating directories using the hjkl, `Enter` and `Backspace` is relatively distant. I added alternative keybindings: `i` for entering a directory ("in") and `o` for exiting a directory ("out"), which are closer to the hjkl and easy to remember.