### PR TITLE
Esc same as Ctrl+C

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Now use `lk` command to start walking.
 | `Enter`          | Enter directory    |
 | `Backspace`      | Exit directory     |
 | `Space`          | Toggle preview     |
-| `Esc`, `q`       | Exit with cd       |
-| `Ctrl+c`         | Exit without cd    |
+| `q`              | Exit with cd       |
+| `Esc`, `Ctrl+c`  | Exit without cd    |
 | `/`              | Fuzzy search       |
 | `dd`             | Delete file or dir |
 | `y`              | yank current dir   |

--- a/main.go
+++ b/main.go
@@ -213,13 +213,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		switch {
-		case key.Matches(msg, keyForceQuit):
+		case key.Matches(msg, keyQuit, keyForceQuit):
 			_, _ = fmt.Fprintln(os.Stderr) // Keep last item visible after prompt.
 			m.exitCode = 2
 			m.dontDoPendingDeletions()
 			return m, tea.Quit
 
-		case key.Matches(msg, keyQuit, keyQuitQ):
+		case key.Matches(msg, keyQuitQ):
 			_, _ = fmt.Fprintln(os.Stderr) // Keep last item visible after prompt.
 			fmt.Println(m.path)            // Write to cd.
 			m.exitCode = 0


### PR DESCRIPTION
Pressing Esc to exit feels as natural as ctrl+c. Might as well stay consistent and let `q` act as exit with cd and `Esc` as exit without cd.

plus ctrl+c is more clicks than just Esc or q.