### PR TITLE
fix: resolve panic on opening empty directories

### DIFF
--- a/main.go
+++ b/main.go
@@ -848,6 +848,11 @@ func leaveOnlyAscii(content []byte) string {
 
 // TODO: Write tests for this function.
 func wrap(files []os.DirEntry, width int, height int, callback func(name string, i, j int)) ([][]string, int, int) {
+	// If the directory is empty, return no names, rows and columns.
+	if len(files) == 0 {
+		return nil, 0, 0
+	}
+
 	// If it's possible to fit all files in one column on a third of the screen,
 	// just use one column. Otherwise, let's squeeze listing in half of screen.
 	columns := len(files) / max(1, height/3)


### PR DESCRIPTION
If one tries to open empty directory, code panics. 

Steps to replicate:
```
go install github.com/antonmedv/walk@v1.9.0
mkdir walktest
walk
```
Entering empty dir `walktest` in tui causes panic.