### PR TITLE
Add warning prompt for special cases in preview mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -756,11 +756,14 @@ func (m *model) preview() {
 	}
 	filePath, ok := m.filePath()
 	if !ok {
+		// Normally this should not happen
+		m.previewContent = warning.Render("Invalid file to preview")
 		return
 	}
 
 	fileInfo, err := os.Stat(filePath)
 	if err != nil {
+		m.previewContent = warning.Render(err.Error())
 		return
 	}
 
@@ -770,7 +773,13 @@ func (m *model) preview() {
 	if fileInfo.IsDir() {
 		files, err := os.ReadDir(filePath)
 		if err != nil {
-			m.previewContent = err.Error()
+			m.previewContent = warning.Render(err.Error())
+			return
+		}
+
+		if len(files) == 0 {
+			m.previewContent = warning.Render("No files")
+			return
 		}
 
 		names, rows, columns := wrap(files, width, height, nil)


### PR DESCRIPTION
Add warning prompt instead of an empty list as preview content, for special cases like no permission, no files, in preview mode.

Effects:
- **Preview directory without permission:**
![图片](https://github.com/antonmedv/walk/assets/3363383/5ff641b0-c878-44e6-9ee5-900d01953317)

- **Preview directory with no files:**
![图片](https://github.com/antonmedv/walk/assets/3363383/4ee54d14-b36b-4833-95a8-b174df3c4115)